### PR TITLE
Correct variable reference parsing a num flag.

### DIFF
--- a/lib/dictionary.js
+++ b/lib/dictionary.js
@@ -350,7 +350,7 @@ Dictionary.prototype.parseRuleCodes = function (textCodes) {
         return flags;
     }
     else if (this.flags.FLAG === "num") {
-        return textCode.split(",");
+        return textCodes.split(",");
     }
 };
 


### PR DESCRIPTION
I just hit this problem, and the fix seems simple enough. It certainly works for me.
