### PR TITLE
suggestion: support current dictionary's alphabet

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -159,7 +159,7 @@ Spellchecker.prototype.suggest = function (word, limit) {
     }
 
     var self = this;
-    self.dict.alphabet = "abcdefghijklmnopqrstuvwxyz";
+    self.dict.alphabet = self.dict.flags.TRY || "abcdefghijklmnopqrstuvwxyz";
 
     /*
     if (!self.alphabet) {


### PR DESCRIPTION
Hi,

Currently  **suggest** function only supports english alphabets. 

I changed a line for support current dictionary's alphabets

Thanks
