### PR TITLE
Fix typo in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Parse and serialize a dictionary
 ```js
 // Parse an hunspell dictionary that can be serialized as JSON
 var DICT = spellchecker.parse({
-    aff: fs.readFileSync("./en_EN.aff");
+    aff: fs.readFileSync("./en_EN.aff"),
     dic: fs.readFileSync("./en_EN.dic")
 });
 ```


### PR DESCRIPTION
I saw this little typo when I copied the example to test the library.