### PR TITLE
Massively speed up the `correct` function.

### DIFF
--- a/lib/dictionary.js
+++ b/lib/dictionary.js
@@ -2,7 +2,7 @@
 var Dictionary = function(dict) {
     this.rules = {};
     this.dictionaryTable = {};
-    this.histograms = {};
+    this.histogramTree = null;
 
     this.compoundRules = [];
     this.compoundRuleCodes = {};
@@ -27,12 +27,37 @@ Dictionary.prototype.toJSON = function(dictionary) {
     return {
         rules: this.rules,
         dictionaryTable: this.dictionaryTable,
-        histograms: this.histograms,
+        histogramTree: this.histogramTree,
         compoundRules: this.compoundRules,
         compoundRuleCodes: this.compoundRuleCodes,
         replacementTable: this.replacementTable,
         flags: this.flags
     };
+};
+
+Dictionary.prototype._initHistogramTree = function () {
+    if (this.histogramTree) {
+        return;
+    }
+
+    var histogramTree = new Array();
+
+    for (var word of Object.keys(this.dictionaryTable)) {
+        var histogram = this._getHistogram(word);
+
+        var cur = histogramTree;
+        for (var i = 0; i < this.alphabet.length; i++) {
+            var count = histogram[i];
+
+            if (!cur[count]) {
+                cur[count] = new Array();
+            }
+            cur = cur[count];
+        }
+        cur.push(word);
+    }
+
+    this.histogramTree = histogramTree;
 };
 
 Dictionary.prototype._getHistogram = function (word) {
@@ -56,6 +81,8 @@ Dictionary.prototype._getHistogram = function (word) {
 Dictionary.prototype.findSimilarWords = function(word, max_distance) {
     var self = this;
     var histogram = this._getHistogram(word);
+
+    this._initHistogramTree();
 
     var rv = [];
 
@@ -81,7 +108,7 @@ Dictionary.prototype.findSimilarWords = function(word, max_distance) {
             walk(i + 1, cur[histogram[i] - 1], distance + 1);
         }
     }
-    walk(0, this.histograms, 0);
+    walk(0, this.histogramTree, 0);
     return rv;
 };
 
@@ -114,24 +141,6 @@ Dictionary.prototype.parse = function(dictionary) {
     }
 
     this.dictionaryTable = this._parseDIC(""+dictionary.dic);
-
-    var histograms = new Array;
-
-    for (var word of Object.keys(this.dictionaryTable)) {
-        var histogram = this._getHistogram(word);
-
-        var cur = histograms;
-        for (var i = 0; i < this.alphabet.length; i++) {
-            var count = histogram[i];
-            if (!cur[count]) {
-                cur[count] = new Array;
-            }
-            cur = cur[count];
-        }
-        cur.push(word);
-    }
-
-    this.histograms = histograms;
 
     // Get rid of any codes from the compound rule codes that are never used
     // (or that were special regex characters).  Not especially necessary...

--- a/lib/dictionary.js
+++ b/lib/dictionary.js
@@ -2,7 +2,7 @@
 var Dictionary = function(dict) {
     this.rules = {};
     this.dictionaryTable = {};
-    this.histogramTree = null;
+    this.dictionaryTree = null;
 
     this.compoundRules = [];
     this.compoundRuleCodes = {};
@@ -13,6 +13,27 @@ var Dictionary = function(dict) {
     this.alphabet = "abcdefghijklmnopqrstuvwxyz";
 
     if (dict) this.load(dict);
+
+    /*
+    if (!this.alphabet) {
+        // Use the alphabet as implicitly defined by the words in the dictionary.
+        var alphaHash = {};
+
+        for (var i in this.dictionaryTable) {
+            for (var j = 0, _len = i.length; j < _len; j++) {
+                alphaHash[i[j]] = true;
+            }
+        }
+
+        for (var i in alphaHash) {
+            this.alphabet += i;
+        }
+
+        var alphaArray = this.alphabet.split("");
+        alphaArray.sort();
+        this.alphabet = alphaArray.join("");
+    }
+    */
 };
 
 // Load from object
@@ -27,7 +48,7 @@ Dictionary.prototype.toJSON = function(dictionary) {
     return {
         rules: this.rules,
         dictionaryTable: this.dictionaryTable,
-        histogramTree: this.histogramTree,
+        dictionaryTree: this.dictionaryTree,
         compoundRules: this.compoundRules,
         compoundRuleCodes: this.compoundRuleCodes,
         replacementTable: this.replacementTable,
@@ -35,80 +56,72 @@ Dictionary.prototype.toJSON = function(dictionary) {
     };
 };
 
-Dictionary.prototype._initHistogramTree = function () {
-    if (this.histogramTree) {
+Dictionary.prototype._initDictionaryTree = function () {
+    if (this.dictionaryTree) {
         return;
     }
 
-    var histogramTree = new Array();
+    var Node = function() {
+        this.word = null;
+        this.children = Object.create(null);
+    };
+
+    var dictionaryTree = new Node();
 
     for (var word of Object.keys(this.dictionaryTable)) {
-        var histogram = this._getHistogram(word);
+        word = word.toLowerCase();
 
-        var cur = histogramTree;
-        for (var i = 0; i < this.alphabet.length; i++) {
-            var count = histogram[i];
-
-            if (!cur[count]) {
-                cur[count] = new Array();
+        var node = dictionaryTree;
+        for (var char of word) {
+            if (!node.children[char]) {
+                node.children[char] = new Node();
             }
-            cur = cur[count];
+            node = node.children[char];
         }
-        cur.push(word);
+        node.word = word;
     }
 
-    this.histogramTree = histogramTree;
-};
-
-Dictionary.prototype._getHistogram = function (word) {
-    word = word.toLowerCase();
-
-    var histogram = new Array(this.alphabet.length);
-
-    for (var i = 0; i < this.alphabet.length; i++) {
-        var char = this.alphabet[i];
-        var count = 0;
-        for (var wordChar of word) {
-            if (wordChar == char) {
-                count ++;
-            }
-        }
-        histogram[i] = count;
-    }
-    return histogram;
+    this.dictionaryTree = dictionaryTree;
 };
 
 Dictionary.prototype.findSimilarWords = function(word, max_distance) {
     var self = this;
-    var histogram = this._getHistogram(word);
-
-    this._initHistogramTree();
+    this._initDictionaryTree();
 
     var rv = [];
 
-    function walk(i, cur, distance) {
-        if (!cur || distance > max_distance) {
+    function walk(remaining, node, distance) {
+        if (!node || distance > max_distance) {
             return;
         }
 
-        if (i == self.alphabet.length)
-        {
-            for (word of cur) {
-                rv.push(word);
-            }
+        if (remaining.length == 0 && node.word) {
+            rv.push(node.word);
+        }
+
+        // insert
+        for (var k = 0; k < self.alphabet.length; k++) {
+            walk(remaining, node.children[self.alphabet[k]], distance + 1);
+        }
+
+        if (remaining.length == 0) {
             return;
         }
 
-        // same frequency
-        walk(i + 1, cur[histogram[i]], distance);
-        // letter inserted
-        walk(i + 1, cur[histogram[i] + 1], distance + 1);
-        if (histogram[i] > 0) {
-            // letter removed
-            walk(i + 1, cur[histogram[i] - 1], distance + 1);
+        // keep
+        walk(remaining.substring(1), node.children[remaining[0]], distance);
+        // remove
+        walk(remaining.substring(1), node, distance + 1);
+        // replace
+        for (var k = 0; k < self.alphabet.length; k++) {
+            walk(remaining.substring(1), node.children[self.alphabet[k]], distance + 1);
+        }
+        // transpose
+        if (remaining.length > 1) {
+            walk(remaining[1] + remaining[0] + remaining.substring(2), node, distance + 1);
         }
     }
-    walk(0, this.histogramTree, 0);
+    walk(word, this.dictionaryTree, 0);
     return rv;
 };
 

--- a/lib/dictionary.js
+++ b/lib/dictionary.js
@@ -2,6 +2,7 @@
 var Dictionary = function(dict) {
     this.rules = {};
     this.dictionaryTable = {};
+    this.histograms = {};
 
     this.compoundRules = [];
     this.compoundRuleCodes = {};
@@ -9,6 +10,7 @@ var Dictionary = function(dict) {
     this.replacementTable = [];
 
     this.flags = {};
+    this.alphabet = "abcdefghijklmnopqrstuvwxyz";
 
     if (dict) this.load(dict);
 };
@@ -25,6 +27,7 @@ Dictionary.prototype.toJSON = function(dictionary) {
     return {
         rules: this.rules,
         dictionaryTable: this.dictionaryTable,
+        histograms: this.histograms,
         compoundRules: this.compoundRules,
         compoundRuleCodes: this.compoundRuleCodes,
         replacementTable: this.replacementTable,
@@ -32,8 +35,60 @@ Dictionary.prototype.toJSON = function(dictionary) {
     };
 };
 
+Dictionary.prototype._getHistogram = function (word) {
+    word = word.toLowerCase();
+
+    var histogram = new Array(this.alphabet.length);
+
+    for (var i = 0; i < this.alphabet.length; i++) {
+        var char = this.alphabet[i];
+        var count = 0;
+        for (var wordChar of word) {
+            if (wordChar == char) {
+                count ++;
+            }
+        }
+        histogram[i] = count;
+    }
+    return histogram;
+};
+
+Dictionary.prototype.findSimilarWords = function(word, max_distance) {
+    var self = this;
+    var histogram = this._getHistogram(word);
+
+    var rv = [];
+
+    function walk(i, cur, distance) {
+        if (!cur || distance > max_distance) {
+            return;
+        }
+
+        if (i == self.alphabet.length)
+        {
+            for (word of cur) {
+                rv.push(word);
+            }
+            return;
+        }
+
+        // same frequency
+        walk(i + 1, cur[histogram[i]], distance);
+        // letter inserted
+        walk(i + 1, cur[histogram[i] + 1], distance + 1);
+        if (histogram[i] > 0) {
+            // letter removed
+            walk(i + 1, cur[histogram[i] - 1], distance + 1);
+        }
+    }
+    walk(0, this.histograms, 0);
+    return rv;
+};
+
 // Parse a dictionary
 Dictionary.prototype.parse = function(dictionary) {
+    var self = this;
+
     if (!dictionary.aff && !dictionary.dic) {
         throw "Invalid dictionary to parse";
     }
@@ -59,6 +114,24 @@ Dictionary.prototype.parse = function(dictionary) {
     }
 
     this.dictionaryTable = this._parseDIC(""+dictionary.dic);
+
+    var histograms = new Array;
+
+    for (var word of Object.keys(this.dictionaryTable)) {
+        var histogram = this._getHistogram(word);
+
+        var cur = histograms;
+        for (var i = 0; i < this.alphabet.length; i++) {
+            var count = histogram[i];
+            if (!cur[count]) {
+                cur[count] = new Array;
+            }
+            cur = cur[count];
+        }
+        cur.push(word);
+    }
+
+    this.histograms = histograms;
 
     // Get rid of any codes from the compound rule codes that are never used
     // (or that were special regex characters).  Not especially necessary...

--- a/lib/dictionary.js
+++ b/lib/dictionary.js
@@ -1,8 +1,7 @@
-
 var Dictionary = function(dict) {
     this.rules = {};
     this.dictionaryTable = {};
-    this.dictionaryTree = null;
+    this.dictionaryTrie = null;
 
     this.compoundRules = [];
     this.compoundRuleCodes = {};
@@ -48,7 +47,7 @@ Dictionary.prototype.toJSON = function(dictionary) {
     return {
         rules: this.rules,
         dictionaryTable: this.dictionaryTable,
-        dictionaryTree: this.dictionaryTree,
+        dictionaryTrie: this.dictionaryTrie,
         compoundRules: this.compoundRules,
         compoundRuleCodes: this.compoundRuleCodes,
         replacementTable: this.replacementTable,
@@ -56,52 +55,56 @@ Dictionary.prototype.toJSON = function(dictionary) {
     };
 };
 
-Dictionary.prototype._initDictionaryTree = function () {
-    if (this.dictionaryTree) {
+Dictionary.prototype._initDictionaryTrie = function () {
+    if (this.dictionaryTrie) {
         return;
     }
 
-    var Node = function() {
-        this.word = null;
-        this.children = Object.create(null);
-    };
+    var Trie = require("./trie");
 
-    var dictionaryTree = new Node();
+    var dictionaryTrie = new Trie();
 
     for (var word of Object.keys(this.dictionaryTable)) {
-        word = word.toLowerCase();
-
-        var node = dictionaryTree;
-        for (var char of word) {
-            if (!node.children[char]) {
-                node.children[char] = new Node();
-            }
-            node = node.children[char];
-        }
-        node.word = word;
+        dictionaryTrie.add(word);
     }
 
-    this.dictionaryTree = dictionaryTree;
+    this.dictionaryTrie = dictionaryTrie;
 };
 
 Dictionary.prototype.findSimilarWords = function(word, max_distance) {
     var self = this;
-    this._initDictionaryTree();
+    this._initDictionaryTrie();
 
     var rv = [];
+    var trace = [];
 
     function walk(remaining, node, distance) {
-        if (!node || distance > max_distance) {
-            return;
+        function recurse(remaining, key, distance) {
+            if (distance > max_distance) {
+                return;
+            }
+
+            trace.push(key);
+            if (!key.length) {
+                walk(remaining, node, distance);
+            }
+            else {
+                var newNode = node.find(key);
+
+                if (newNode) {
+                    walk(remaining, newNode, distance);
+                }
+            }
+            trace.pop();
         }
 
-        if (remaining.length == 0 && node.word) {
-            rv.push(node.word);
+        if (remaining.length == 0 && node.fragment.length == 0 && node.isWord) {
+            rv.push(trace.join(''));
         }
 
         // insert
         for (var k = 0; k < self.alphabet.length; k++) {
-            walk(remaining, node.children[self.alphabet[k]], distance + 1);
+            recurse(remaining, self.alphabet[k], distance + 1);
         }
 
         if (remaining.length == 0) {
@@ -109,26 +112,24 @@ Dictionary.prototype.findSimilarWords = function(word, max_distance) {
         }
 
         // keep
-        walk(remaining.substring(1), node.children[remaining[0]], distance);
+        recurse(remaining.substring(1), remaining[0], distance);
         // remove
-        walk(remaining.substring(1), node, distance + 1);
+        recurse(remaining.substring(1), "", distance + 1);
         // replace
         for (var k = 0; k < self.alphabet.length; k++) {
-            walk(remaining.substring(1), node.children[self.alphabet[k]], distance + 1);
+            recurse(remaining.substring(1), self.alphabet[k], distance + 1);
         }
         // transpose
         if (remaining.length > 1) {
-            walk(remaining[1] + remaining[0] + remaining.substring(2), node, distance + 1);
+            recurse(remaining[1] + remaining[0] + remaining.substring(2), "", distance + 1);
         }
     }
-    walk(word, this.dictionaryTree, 0);
+    walk(word, this.dictionaryTrie, 0);
     return rv;
 };
 
 // Parse a dictionary
 Dictionary.prototype.parse = function(dictionary) {
-    var self = this;
-
     if (!dictionary.aff && !dictionary.dic) {
         throw "Invalid dictionary to parse";
     }

--- a/lib/dictionary.js
+++ b/lib/dictionary.js
@@ -64,7 +64,7 @@ Dictionary.prototype._initDictionaryTrie = function () {
 
     var dictionaryTrie = new Trie();
 
-    for (var word of Object.keys(this.dictionaryTable)) {
+    for (var word in this.dictionaryTable) {
         dictionaryTrie.add(word);
     }
 
@@ -78,53 +78,53 @@ Dictionary.prototype.findSimilarWords = function(word, max_distance) {
     var rv = [];
     var trace = [];
 
-    function walk(remaining, node, distance) {
-        function recurse(remaining, key, distance) {
+    function walk(word, offset, node, distance) {
+        function recurse(word, offset, key, distance) {
             if (distance > max_distance) {
                 return;
             }
 
             trace.push(key);
             if (!key.length) {
-                walk(remaining, node, distance);
+                walk(word, offset, node, distance);
             }
             else {
-                var newNode = node.find(key);
+                var newNode = node.findChar(key);
 
                 if (newNode) {
-                    walk(remaining, newNode, distance);
+                    walk(word, offset, newNode, distance);
                 }
             }
             trace.pop();
         }
 
-        if (remaining.length == 0 && node.fragment.length == 0 && node.isWord) {
+        if (word.length == offset && node.fragment.length == 0 && node.isWord) {
             rv.push(trace.join(''));
         }
 
         // insert
         for (var k = 0; k < self.alphabet.length; k++) {
-            recurse(remaining, self.alphabet[k], distance + 1);
+            recurse(word, offset, self.alphabet[k], distance + 1);
         }
 
-        if (remaining.length == 0) {
+        if (word.length == offset) {
             return;
         }
 
         // keep
-        recurse(remaining.substring(1), remaining[0], distance);
+        recurse(word, offset + 1, word[offset], distance);
         // remove
-        recurse(remaining.substring(1), "", distance + 1);
+        recurse(word, offset + 1, "", distance + 1);
         // replace
         for (var k = 0; k < self.alphabet.length; k++) {
-            recurse(remaining.substring(1), self.alphabet[k], distance + 1);
+            recurse(word, offset + 1, self.alphabet[k], distance + 1);
         }
         // transpose
-        if (remaining.length > 1) {
-            recurse(remaining[1] + remaining[0] + remaining.substring(2), "", distance + 1);
+        if ((word.length - offset) > 1) {
+            recurse(word[offset + 1] + word[offset] + word.substring(offset + 2), 0, "", distance + 1);
         }
     }
-    walk(word, this.dictionaryTrie, 0);
+    walk(word, 0, this.dictionaryTrie, 0);
     return rv;
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -159,7 +159,6 @@ Spellchecker.prototype.suggest = function (word, limit) {
     }
 
     var self = this;
-    self.dict.alphabet = "abcdefghijklmnopqrstuvwxyz";
 
     /*
     if (!self.alphabet) {
@@ -261,10 +260,21 @@ Spellchecker.prototype.suggest = function (word, limit) {
 
     function correct(word) {
         // Get the edit-distance-1 and edit-distance-2 forms of this word.
-        var ed1 = edits1([word]);
-        var ed2 = edits1(ed1);
+        var wordEdits = new Set(edits1([word]));
+        var suggestions = self.dict.findSimilarWords(word, 2);
 
-        var corrections = known(ed1).concat(known(ed2));
+        var corrections = [];
+        for (var suggestion of suggestions) {
+            if (wordEdits.has(suggestion)) {
+                corrections.push(suggestion);
+            }
+
+            for (var edit of edits1([suggestion])) {
+                if (wordEdits.has(edit)) {
+                    corrections.push(suggestion);
+                }
+            }
+        }
 
         // Sort the edits based on how many different ways they were created.
         var weighted_corrections = {};

--- a/lib/index.js
+++ b/lib/index.js
@@ -160,92 +160,6 @@ Spellchecker.prototype.suggest = function (word, limit) {
 
     var self = this;
 
-    /*
-    if (!self.alphabet) {
-        // Use the alphabet as implicitly defined by the words in the dictionary.
-        var alphaHash = {};
-
-        for (var i in self.dictionaryTable) {
-            for (var j = 0, _len = i.length; j < _len; j++) {
-                alphaHash[i[j]] = true;
-            }
-        }
-
-        for (var i in alphaHash) {
-            self.alphabet += i;
-        }
-
-        var alphaArray = self.alphabet.split("");
-        alphaArray.sort();
-        self.alphabet = alphaArray.join("");
-    }
-    */
-
-    function edits1(words) {
-        var rv = [];
-
-        for (var ii = 0, _iilen = words.length; ii < _iilen; ii++) {
-            var word = words[ii];
-
-            var splits = [];
-
-            for (var i = 0, _len = word.length + 1; i < _len; i++) {
-                splits.push([ word.substring(0, i), word.substring(i, word.length) ]);
-            }
-
-            var deletes = [];
-
-            for (var i = 0, _len = splits.length; i < _len; i++) {
-                var s = splits[i];
-
-                if (s[1]) {
-                    deletes.push(s[0] + s[1].substring(1));
-                }
-            }
-
-            var transposes = [];
-
-            for (var i = 0, _len = splits.length; i < _len; i++) {
-                var s = splits[i];
-
-                if (s[1].length > 1) {
-                    transposes.push(s[0] + s[1][1] + s[1][0] + s[1].substring(2));
-                }
-            }
-
-            var replaces = [];
-
-            for (var i = 0, _len = splits.length; i < _len; i++) {
-                var s = splits[i];
-
-                if (s[1]) {
-                    for (var j = 0, _jlen = self.dict.alphabet.length; j < _jlen; j++) {
-                        replaces.push(s[0] + self.dict.alphabet[j] + s[1].substring(1));
-                    }
-                }
-            }
-
-            var inserts = [];
-
-            for (var i = 0, _len = splits.length; i < _len; i++) {
-                var s = splits[i];
-
-                if (s[1]) {
-                    for (var j = 0, _jlen = self.dict.alphabet.length; j < _jlen; j++) {
-                        replaces.push(s[0] + self.dict.alphabet[j] + s[1]);
-                    }
-                }
-            }
-
-            rv = rv.concat(deletes);
-            rv = rv.concat(transposes);
-            rv = rv.concat(replaces);
-            rv = rv.concat(inserts);
-        }
-
-        return rv;
-    }
-
     function known(words) {
         var rv = [];
 
@@ -259,22 +173,7 @@ Spellchecker.prototype.suggest = function (word, limit) {
     }
 
     function correct(word) {
-        // Get the edit-distance-1 and edit-distance-2 forms of this word.
-        var wordEdits = new Set(edits1([word]));
-        var suggestions = self.dict.findSimilarWords(word, 2);
-
-        var corrections = [];
-        for (var suggestion of suggestions) {
-            if (wordEdits.has(suggestion)) {
-                corrections.push(suggestion);
-            }
-
-            for (var edit of edits1([suggestion])) {
-                if (wordEdits.has(edit)) {
-                    corrections.push(suggestion);
-                }
-            }
-        }
+        var corrections = self.dict.findSimilarWords(word, 2);
 
         // Sort the edits based on how many different ways they were created.
         var weighted_corrections = {};

--- a/lib/trie.js
+++ b/lib/trie.js
@@ -5,10 +5,9 @@ var Trie = function(fragment, isWord, children) {
 };
 
 Trie.prototype.toJSON = function() {
-    var childrenJSON = [];
-    for (var child of this.children) {
-        childrenJSON.push(child.toJSON());
-    }
+    var childrenJSON = this.children.map(function(child) {
+        return child.toJSON();
+    });
     return {
         fragment: this.fragment,
         isWord: this.isWord,
@@ -47,7 +46,8 @@ Trie.prototype.add = function (word) {
     var rightWord = word.substring(commonFragment);
 
     if (this.children) {
-        for (var child of this.children) {
+        for (var i = 0; i < this.children.length; i++) {
+            var child = this.children[i];
             if (this.commonPrefix(child.fragment, rightWord) > 0) {
                 child.add(rightWord);
                 return;
@@ -76,7 +76,8 @@ Trie.prototype.findChar = function (char) {
     if (this.fragment.length == 0) {
         // root
         if (this.children) {
-            for (var child of this.children) {
+            for (var i = 0; i < this.children.length; i++) {
+                var child = this.children[i];
                 var res = child.findChar(char);
                 if (res) return res;
             }

--- a/lib/trie.js
+++ b/lib/trie.js
@@ -62,29 +62,6 @@ Trie.prototype.add = function (word) {
     }
 };
 
-Trie.prototype.find = function (word) {
-    var commonFragment = this.commonPrefix(this.fragment, word);
-
-    if (this.fragment.length != 0 && commonFragment == 0) {
-        return null;
-    }
-    if (this.children && commonFragment == this.fragment.length) {
-        var rightWord = word.substring(commonFragment);
-
-        for (var child of this.children) {
-            var res = child.find(rightWord);
-            if (res) return res;
-        }
-    }
-    if (commonFragment == 0) {
-        return null;
-    }
-
-    var rightFragment = this.fragment.substring(commonFragment);
-
-    return new Trie(rightFragment, this.isWord, this.children);
-};
-
 Trie.prototype.commonPrefix = function (left, right) {
     var min_len = Math.min(left.length, right.length);
     for (var i = 0; i < min_len; i++) {
@@ -93,6 +70,25 @@ Trie.prototype.commonPrefix = function (left, right) {
         }
     }
     return min_len;
+};
+
+Trie.prototype.findChar = function (char) {
+    if (this.fragment.length == 0) {
+        // root
+        if (this.children) {
+            for (var child of this.children) {
+                var res = child.findChar(char);
+                if (res) return res;
+            }
+        }
+        return null;
+    }
+
+    if (this.fragment[0] == char) {
+        return new Trie(this.fragment.substring(1), this.isWord, this.children);
+    }
+
+    return null;
 };
 
 module.exports = Trie;

--- a/lib/trie.js
+++ b/lib/trie.js
@@ -1,0 +1,98 @@
+var Trie = function(fragment, isWord, children) {
+    this.fragment = fragment || "";
+    this.isWord = isWord || false;
+    this.children = children || null;
+};
+
+Trie.prototype.toJSON = function() {
+    var childrenJSON = [];
+    for (var child of this.children) {
+        childrenJSON.push(child.toJSON());
+    }
+    return {
+        fragment: this.fragment,
+        isWord: this.isWord,
+        children: childrenJSON
+    };
+};
+
+/**
+    * foo, foobar, flop, fweeh
+    * ("")
+    * -> ("foo")
+    * -> ("foo", [("bar")])
+    * -> ("f", [("oo", [("bar")]), ("lop")])
+    * -> ("f", [("oo", [("bar")]), ("lop"), ("weeh")])
+    */
+Trie.prototype.add = function (word) {
+    if (this.fragment == word) {
+        this.isWord = true;
+        return;
+    }
+    if (!this.fragment.length && !this.children) {
+        this.fragment = word;
+        this.isWord = true;
+        return;
+    }
+    var commonFragment = this.commonPrefix(this.fragment, word);
+
+    if (commonFragment < this.fragment.length) {
+        var leftFragment = this.fragment.substring(0, commonFragment);
+        var rightFragment = this.fragment.substring(commonFragment);
+
+        this.fragment = leftFragment;
+        this.children = [new Trie(rightFragment, this.isWord, this.children)];
+        this.isWord = false;
+    }
+    var rightWord = word.substring(commonFragment);
+
+    if (this.children) {
+        for (var child of this.children) {
+            if (this.commonPrefix(child.fragment, rightWord) > 0) {
+                child.add(rightWord);
+                return;
+            }
+        }
+    }
+    if (this.children) {
+        this.children.push(new Trie(rightWord, true));
+    }
+    else {
+        this.children = [new Trie(rightWord, true)];
+    }
+};
+
+Trie.prototype.find = function (word) {
+    var commonFragment = this.commonPrefix(this.fragment, word);
+
+    if (this.fragment.length != 0 && commonFragment == 0) {
+        return null;
+    }
+    if (this.children && commonFragment == this.fragment.length) {
+        var rightWord = word.substring(commonFragment);
+
+        for (var child of this.children) {
+            var res = child.find(rightWord);
+            if (res) return res;
+        }
+    }
+    if (commonFragment == 0) {
+        return null;
+    }
+
+    var rightFragment = this.fragment.substring(commonFragment);
+
+    return new Trie(rightFragment, this.isWord, this.children);
+};
+
+Trie.prototype.commonPrefix = function (left, right) {
+    var min_len = Math.min(left.length, right.length);
+    for (var i = 0; i < min_len; i++) {
+        if (left[i] != right[i]) {
+            return i;
+        }
+    }
+    return min_len;
+};
+
+module.exports = Trie;

--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
     "homepage": "https://github.com/GitbookIO/hunspell-spellchecker",
     "description": "Parse and use Hunspell dictionaries in Javascript",
     "main": "lib/index.js",
-    "dependencies": {
-
-    },
+    "dependencies": {},
     "devDependencies": {
         "mocha": "2.2.1",
         "gulp": "3.8.11",

--- a/test/check.js
+++ b/test/check.js
@@ -12,6 +12,20 @@ describe("Dictionary", function() {
         aff: fs.readFileSync(path.resolve(__dirname, "fixtures/test.aff"))
     });
 
+    it("should return suggestions", function() {
+        function uniq(array) {
+            return Array.from(new Set(array));
+        }
+
+        // character replaced
+        assert.deepEqual(uniq(sp.dict.findSimilarWords("hellp", 1)), ["hello"]);
+        // character added
+        assert.deepEqual(uniq(sp.dict.findSimilarWords("hellos", 1)), ["hello"]);
+        // character removed
+        assert.deepEqual(uniq(sp.dict.findSimilarWords("helo", 1)), ["hello"]);
+        // characters transposed
+        assert.deepEqual(uniq(sp.dict.findSimilarWords("hlelo", 1)), ["hello"]);
+    });
 
     it("should correctly signal a correct word", function() {
         assert(sp.check("hello"));


### PR DESCRIPTION
Massively speed up the `correct` function.

`correct` is slow because it calls `edit1` twice recursive. Especially for long words, this can lead to low millions of words to generate and test.

~~Instead: build a trie of letter histograms for every word in the dictionary. Then, add a function `findSimilarWords` to find words whose histogram is similar to the one provided plus some changes. Use this to find candidate words for an edit distance of 2 (histogram distance of 4; two replaces). Then do a bidirectional comparison to find the words that actually match.~~

Instead: build a recursive ~~tree~~trie of all the words in the dictionary. Then, add a function `findSimilarWords` that walks the tree using a provided word as a guide, making changes during iteration, and aborting when the current set of changes leads to a dead end.

Tree initialization is lazily done once `correct` is called. It takes ~~about two seconds~~ ~~less than a second~~ maybe 400ms. After that, `correct` is effectively instant (~10ms on en_US).

~~Further ideas for improvements: a proper trie data structure could be used for performance.~~ Done!