### PR TITLE
Update README.md to include copyright notice - Important for consuming Apache licensed libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,6 @@ Check a word:
 // Check a word
 var isRight = spellchecker.check("tll");
 ```
+
+### License
+Copyright 2019 Samy Pessé <samypesse@gmail.com>


### PR DESCRIPTION
Apache license needs the consuming applications to provide attribution to the module owner. However I could not find the copyright notice in the module. Hence adding the copyright notice in the readme so that it can be pulled in by consuming applications.

=======
We are trying to consume eslint-plugin-spellcheck which uses this internally. Please review and approve.