### PR TITLE
Only remove comments (starting with '#') if they begin a line.

### DIFF
--- a/lib/dictionary.js
+++ b/lib/dictionary.js
@@ -205,7 +205,8 @@ Dictionary.prototype._parseAFF = function (data) {
  */
 Dictionary.prototype._removeAffixComments = function (data) {
     // Remove comments
-    data = data.replace(/#.*$/mg, "");
+    // ('#' can sometimes be used in compound rules [e.g. LibreOffice - en_GB.aff] so only remove comments if they begin the line.)
+    data = data.replace(/^#.*$/mg, "");
 
     // Trim each line
     data = data.replace(/^\s\s*/m, '').replace(/\s\s*$/m, '');


### PR DESCRIPTION
This is due to some dictionaries using '#' in compound rules.

Fix for #21 